### PR TITLE
add a dogstatsd tag filter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -339,6 +339,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
+	config.BindEnvAndSetDefault("dogstatsd_tag_filters", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)
 	// Enable check for Entity-ID presence when enriching Dogstatsd metrics with tags

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1071,6 +1071,20 @@ api_key:
 # dogstatsd_tags:
 #   - <TAG_KEY>:<TAG_VALUE>
 
+## @param dogstatsd_tag_filters - list of regular expressions - optional
+## List of regular expressions used to filter out (remove) tags from incoming dogstatsd samples.
+#
+# dogstatsd_tag_filters:
+## Remove any tag that matches "tag_name:tag_value":
+#   - tag_name:tag_value
+## Remove any tag with an empty value:
+#   - :$
+## Remove any tag containing a UUID:
+#   - [a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}
+## Strip an unwanted string suffix from a tag:
+#   - ^(?P<Keep>calling_service:[^/]+)  # calling_service:foo/1.2.3 => calling_service:foo
+
+
 ## @param dogstatsd_mapper_profiles - list of custom object - optional
 ## The profiles will be used to convert parts of metrics names into tags.
 ## If a profile prefix is matched, other profiles won't be tried even if that profile matching rules doesn't match.

--- a/pkg/dogstatsd/filter/filter.go
+++ b/pkg/dogstatsd/filter/filter.go
@@ -1,0 +1,62 @@
+package filter
+
+import (
+	"regexp"
+	"strings"
+)
+
+type TagFilter struct {
+	filters []*regexp.Regexp
+}
+
+func NewTagFilter(regexes []string) (*TagFilter, error) {
+	filters := make([]*regexp.Regexp, len(regexes))
+	for i, r := range regexes {
+		if regex, err := regexp.Compile(r); err != nil {
+			return nil, err
+		} else {
+			filters[i] = regex
+		}
+	}
+
+	return &TagFilter{
+		filters: filters,
+	}, nil
+}
+
+func (tf *TagFilter) Filter(tags []string) []string {
+	var i int
+	for _, t := range tags {
+		if ok, result := tf.filter(t); ok {
+			tags[i] = result
+			i++
+		}
+	}
+
+	// Prevent memory leak by erasing truncated values
+	for j := i; j < len(tags); j++ {
+		tags[j] = ""
+	}
+
+	return tags[:i]
+}
+
+func (tf *TagFilter) filter(tag string) (bool, string) {
+	OUTER:
+	for _, regex := range tf.filters {
+		if m := regex.FindStringSubmatch(tag); m != nil {
+			for i, name := range regex.SubexpNames() {
+				if name == "Keep" {
+					if strings.Contains(m[i], ":") {
+						tag = m[i]
+					}
+					continue OUTER
+				}
+			}
+
+			return false, ""
+		}
+	}
+
+	return true, tag
+}

--- a/pkg/dogstatsd/filter/filter.go
+++ b/pkg/dogstatsd/filter/filter.go
@@ -12,13 +12,13 @@ type TagFilter struct {
 func NewTagFilter(regexes []string) (*TagFilter, error) {
 	filters := make([]*regexp.Regexp, len(regexes))
 	for i, r := range regexes {
-		if regex, err := regexp.Compile(r); err != nil {
+		regex, err := regexp.Compile(r)
+		if err != nil {
 			return nil, err
-		} else {
-			filters[i] = regex
 		}
-	}
 
+		filters[i] = regex
+	}
 	return &TagFilter{
 		filters: filters,
 	}, nil
@@ -42,7 +42,7 @@ func (tf *TagFilter) Filter(tags []string) []string {
 }
 
 func (tf *TagFilter) filter(tag string) (bool, string) {
-	OUTER:
+OUTER:
 	for _, regex := range tf.filters {
 		if m := regex.FindStringSubmatch(tag); m != nil {
 			for i, name := range regex.SubexpNames() {

--- a/pkg/dogstatsd/filter/filter_test.go
+++ b/pkg/dogstatsd/filter/filter_test.go
@@ -1,0 +1,97 @@
+package filter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagFilter_Filter(t *testing.T) {
+	type args struct {
+		tags []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "nil",
+			args: args{},
+			want: nil,
+		},
+		{
+			name: "empty",
+			args: args{[]string{}},
+			want: []string{},
+		},
+		{
+			name: "unchanged",
+			args: args{[]string{"key:value"}},
+			want: []string{"key:value"},
+		},
+		{
+			name: "filtered",
+			args: args{[]string{"key:drop_me"}},
+			want: []string{},
+		},
+		{
+			name: "mangled",
+			args: args{[]string{"calling_service:foo/e84f81f89e3876b2b11db348e95c8ab056e134ac"}},
+			want: []string{"calling_service:foo"},
+		},
+		{
+			name: "keep match group that removes colon separator",
+			args: args{[]string{"keep:without colon"}},
+			want: []string{"keep:without colon"},
+		},
+		{
+			name: "drop untitled match group",
+			args: args{[]string{"drop:untitled match group"}},
+			want: []string{},
+		},
+		{
+			name: "drop after mangled",
+			args: args{[]string{"drop:after mangled"}},
+			want: []string{},
+		},
+		{
+			name: "multi tag filter",
+			args: args{[]string{
+				"calling_service:foo/e84f81f89e3876b2b11db348e95c8ab056e134ac",
+				"key:drop_me",
+				"key:value",
+				"version:",
+				"version:1.0.0",
+				"request_id:CA761232-ED42-11CE-BACD-00AA0057B223",
+				"request_source:CA761232-ED42-11CE-BACD-00AA0057B223",
+				"request_source:genCA761232-ED42-11CE-BACD-00AA0057B223",
+			}},
+			want: []string{
+				"calling_service:foo",
+				"key:value",
+				"version:1.0.0",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf, err := NewTagFilter([]string{
+				// A match group named "Keep" will remove anything not matched by the match group
+				"^(?P<Keep>calling_service:[^/]+)",
+				"(?P<Keep>without colon)",
+				"(?P<Keep>drop:after)",
+				":$", // remove empty string tag values
+				"^drop:after$",
+				"(untitled match group)",
+				`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`, // uuid
+				"drop_me",
+			})
+			assert.NoError(t, err)
+			if got := tf.Filter(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Filter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a filtering capability to the dogstatsd server that removes or modifies undesirable tags.

### Motivation

Many statsd clients out there add undesirable tags to their metrics that result in inaccurate histograms and financial burden.  For example, some libraries add an extremely high cardinality tag called `request_id`.  Some libraries add UUID's into tag values.  Tags with empty string values also mess up the Datadog UI.   The use cases for this are plentiful.

### Additional Notes

No.

### Describe your test plan

Run the agent with:

```DD_DOGSTATSD_TAG_FILTERS='[":$", "^undesirable_tag:", ":undesirable_value"]'```
